### PR TITLE
Reload and suggest

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['modcloth-hostname']['ip'] = node['privateaddress']

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,5 @@ maintainer_email  'github+modcloth-hostname-cookbook@modcloth.com'
 license           'MIT'
 description       'Get thyself a hostname'
 version           '0.1.0'
+
+suggests 'ipaddr_extensions'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,3 +33,7 @@ when 'centos'
 when 'ubuntu'
   include_recipe 'modcloth-hostname::ubuntu'
 end
+
+ohai "reload" do
+  action :reload
+end

--- a/templates/default/hosts.erb
+++ b/templates/default/hosts.erb
@@ -2,4 +2,4 @@
 # changes will be lost
 
 127.0.0.1	localhost
-<%= node['privateaddress'] %> <%= node.name %> <%= node.name.split('.').first rescue '' %>
+<%= node['modcloth_hostname']['ip'] %> <%= node.name %> <%= node.name.split('.').first rescue '' %>


### PR DESCRIPTION
Yarrh. We got a pull request with some extensions, and I realized that suggesting ipaddr_extensions would possibly be helpful, as it is needed for `node['privateaddress']` to resolve.

Plus we should reload ohai after setting the hostname, otherwise it won't know!
